### PR TITLE
Ignore `--gruntfile` option

### DIFF
--- a/tasks/cypress.js
+++ b/tasks/cypress.js
@@ -18,7 +18,8 @@ module.exports = (grunt) => {
     
      // Get arguments and options.
     const args = [...arguments];
-    const opts = grunt.option.flags();
+    const opts = grunt.option.flags()
+      .filter(option => !option.includes('--gruntfile') );
     
     // Use the open method by default.
     if( args.length === 0 ) args.push('open');


### PR DESCRIPTION
Cypress does not recognize this option and will fail.

I have observed this behavior with:
grunt-cli v1.3.2
grunt v1.0.3